### PR TITLE
画像を表示

### DIFF
--- a/show_image/show_image.html
+++ b/show_image/show_image.html
@@ -1,0 +1,51 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/105/three.min.js"></script>
+  </head>
+  <body>
+  </body>
+  <script>
+
+    // set size
+    const width = 960
+    const height = 540
+
+    const scene = new THREE.Scene()
+
+    const renderer = new THREE.WebGLRenderer({
+      alpha: true,
+      antialias: true
+    })
+    renderer.setClearColor(0xFFFFFF, 1)
+    renderer.setSize(width, height)
+    renderer.setPixelRatio(window.devicePixelRatio)
+    document.body.appendChild(renderer.domElement)
+
+    const camera = new THREE.PerspectiveCamera(50, width / height, 1, 10000)
+    camera.position.set(0, 0, 10)
+
+    const light = new THREE.AmbientLight(0xFFFFFF)
+    scene.add(light)
+
+    const texture = new THREE.TextureLoader().load('/imgs/earthmap1k.jpg',
+    (tex) => {
+      const w = 5
+      const h = tex.image.height/(tex.image.width/w)
+
+      const geometry = new THREE.PlaneGeometry(1, 1)
+      const material = new THREE.MeshPhongMaterial({map: texture})
+      const plane = new THREE.Mesh(geometry, material)
+      plane.scale.set(w, h, 1)
+      scene.add(plane)
+    })
+
+    const render = () => {
+      requestAnimationFrame(render)
+      renderer.render(scene, camera)
+    }
+
+    render()
+
+  </script>
+</html>


### PR DESCRIPTION
**学び**
- WebGLRendererの初期化

前回まで
```javascript
const renderer = new THREE.WebGLRenderer({
  canvas: document.getElementById('myCanvas')
})
```
canvasと共にWebGLRendererを初期化してた。
モダンなやり方？
`document.body.appendChild(renderer.domElement)`
documentのbodyにrendererが吐き出したDOMElementをappendChildしてる

- 画像表示に向けたmesh作成

```javascript
const geometry = new THREE.PlaneGeometry(1, 1)
const material = new THREE.MeshPhongMaterial({map: texture})
```
> PlaneGeometry（平面）は、平面のジオメトリです。よく地面に使われているようです。
画像は2Dだからこのジオメトリを使っていく感じになると思う。

> THREE.MeshPhongMaterialクラスはフォン・シェーディングと言う、光沢感のある質感を表現できるマテリアルです。

光沢感のある質感。画像で使う意味は？？
> THREE.MeshStandardMaterialクラスは物理ベースレンダリングのマテリアルです。物理ベースレンダリングは多くの3Dアプリケーションで実装されているもので（UnityやUnrealなど）、光の反射や散乱など現実の物理現象を再現します。先述のMeshPhongMaterialやMeshLambertMaterialよりも調整できることが多く、現実味のある表現ができます。

こっちのほうがいいのでは？
